### PR TITLE
shave off 5544 bytes with LTO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -3,7 +3,7 @@ platform = heltec-cubecell
 board = cubecell_board
 framework = arduino
 monitor_speed = 115200
-
+platform_packages = framework-arduinocubecell@https://github.com/H3wastooshort/CubeCell-Arduino#3866b52c792d676da2b2ce3e64a94c825ef48cc6 ;allow LTO and fix some bad decisions in Arduino.h
 build_flags =
     -D CUBECELL
     ; Size optimization flags from reference project
@@ -15,6 +15,9 @@ build_flags =
     -ffunction-sections
     -fdata-sections
     -Wl,--gc-sections
+    -fuse-linker-plugin
+    -flto=full
+    -fwhole-program
     -finline-limit=30
     ; RadioLib - exclude unused radio modules (project uses SX1262 only)
     -D RADIOLIB_EXCLUDE_CC1101=1


### PR DESCRIPTION
I have messed around with the original MeshCore firmware, trying to fit it into the PSoC4's memory. I that process, I have managed to make Link-Time Optimization work, by marking some internal functions as "used", so they don't get removed. This saves about 5kB on this project, but needs my slightly modified fork of CubeCell-Arduino. Feel free to fork my fork, if you intend to merge this.

before:
```
RAM:   [=====     ]  52.4% (used 8584 bytes from 16384 bytes)
Flash: [==========]  99.5% (used 130432 bytes from 131072 bytes)
```

with LTO:
```
RAM:   [=====     ]  51.6% (used 8448 bytes from 16384 bytes)
Flash: [==========]  95.3% (used 124888 bytes from 131072 bytes)
```

As i have not tested these changes in production, I am keeping this a Draft for now.